### PR TITLE
Adopt `snake_case` in gh workflow vars

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
           repo_tag=${{ steps.latest_tag.outputs.tag }}
-          image_tag=${{ matrix.images.imageTag }}.${repo_tag}
+          image_tag=${{ matrix.images.imageTag }}.${repo_tag//\//-}
           dev_image_tag="${image_tag}"
           image_ref="${image_name}:${image_tag}"
           short_image_ref="${{ env.CONTAINER_NAME }}:${image_tag}"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,10 +2,9 @@ name: build-and-push
 
 on:
   push:
-    # branches:
-    #   - feature/*
     tags:
-      - "*"
+      - "**.**.**"
+      - feature/**/**
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
@@ -78,23 +77,21 @@ jobs:
         id: variables
         run: |
           image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
-          image_tag=${{ matrix.images.imageTag }}.${{ steps.latest_tag.outputs.tag }}
-          dev_image_tag="${image_tag}-dev"
+          repo_tag=${{ steps.latest_tag.outputs.tag }}
+          image_tag=${{ matrix.images.imageTag }}.${repo_tag}
+          dev_image_tag="${image_tag}"
           image_ref="${image_name}:${image_tag}"
           short_image_ref="${{ env.CONTAINER_NAME }}:${image_tag}"
           dev_image_ref="$image_name:$dev_image_tag"
           short_dev_image_ref="${{ env.CONTAINER_NAME }}:$dev_image_tag"
 
-          echo "::set-output name=image-name::$image_name"
-
-          echo "::set-output name=image-tag::$image_tag"
-          echo "::set-output name=dev-image-tag::$dev_image_tag"
-
-          echo "::set-output name=image-ref::$image_ref"
-          echo "::set-output name=short-image-ref::$short_image_ref"
-
-          echo "::set-output name=dev-image-ref::$dev_image_ref"
-          echo "::set-output name=short-dev-image-ref::$short_dev_image_ref"
+          echo "::set-output name=image_name::$image_name"
+          echo "::set-output name=image_tag::$image_tag"
+          echo "::set-output name=dev_image_tag::$dev_image_tag"
+          echo "::set-output name=image_ref::$image_ref"
+          echo "::set-output name=short_image_ref::$short_image_ref"
+          echo "::set-output name=dev_image_ref::$dev_image_ref"
+          echo "::set-output name=short_dev_image_ref::$short_dev_image_ref"
 
       - name: Set up Docker Buildx
         if: steps.run_state.outputs.run_docker_build == 'true'
@@ -108,13 +105,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build ${{ steps.variables.outputs.short-image-ref }}
+      - name: Build ${{ steps.variables.outputs.short_image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
         uses: docker/build-push-action@v2
         id: docker_build
         with:
           context: .
-          tags: ${{ steps.variables.outputs.image-ref }}
+          tags: ${{ steps.variables.outputs.image_ref }}
           file: ${{ matrix.images.dockerfile }}
           push: true
           pull: false
@@ -126,27 +123,22 @@ jobs:
             USERNAME=${{ env.CONTAINER_USERNAME }}
             GROUP=${{ env.CONTAINER_GROUP }}
 
-      - name: Build devcontainer ${{ steps.variables.outputs.short-dev-image-ref }}
+      - name: Build devcontainer ${{ steps.variables.outputs.short_dev_image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
         id: devcontainer_build
         uses: devcontainers/ci@v0.2
         env:
-          IMAGE_NAME: ${{ steps.variables.outputs.image-name }}
-          IMAGE_TAG: ${{ steps.variables.outputs.image-tag }}
+          IMAGE_NAME: ${{ steps.variables.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.variables.outputs.image_tag }}
         with:
-          imageName: ${{ steps.variables.outputs.image-name }}
-          imageTag: ${{ steps.variables.outputs.image-tag }}
+          imageName: ${{ steps.variables.outputs.image_name }}
+          imageTag: ${{ steps.variables.outputs.image_tag }}
           subFolder: src
-          runCmd: |-
-            gh --version
-            node --version
-            node <<EOF
-            console.log("Node runs as expected");
-            EOF
+          runCmd: /scripts/devcontainer-check.sh
 
-      - name: Push devcontainer ${{ steps.variables.outputs.short-dev-image-ref }}
+      - name: Push devcontainer ${{ steps.variables.outputs.short_dev_image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
-        run: docker push ${{ steps.variables.outputs.image-ref }}
+        run: docker push ${{ steps.variables.outputs.image_ref }}
 
       - name: Set Docker Hub description
         if: steps.run_state.outputs.run_docker_build == 'true'
@@ -154,7 +146,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ steps.variables.outputs.image-name }}
+          repository: ${{ steps.variables.outputs.image_name }}
           short-description: NodeJS devcontainers
           readme-filepath: ${{ matrix.images.readmeFile }}
 

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -32,3 +32,5 @@ RUN chmod +x \
   /scripts/create-env-example.sh \
   /home/$USERNAME/.bashrc \
   /home/$USERNAME/.inputrc
+
+COPY src/scripts /scripts

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+required_packages="gh node vim git"
+
+for exec in $required_packages;
+do
+  if [ -z "$(which $exec)" ];
+  then
+    echo "Error: $exec is not available inside the container"
+    exit 1
+  fi
+done
+
+node <<EOF
+console.log("Node runs as expected");
+EOF


### PR DESCRIPTION
- Alters the `variables` section of `build-and-push` workflow to use `snake_case` for variable names. There seems to be no concensus on which casing is preferred among the community but github itself uses this casing.
- Alters the triggers to fire for tags that follow semver or starts with `feature`.
