### PR TITLE
Feat: Add nvim, remove vim

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,7 +4,8 @@ on:
   push:
     tags:
       - "**.**.**"
-      - feature/**/**
+    branches:
+      - experiment/**/**
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
@@ -16,6 +17,7 @@ env:
   CONTAINER_GROUP: 1000
   CACHE_TO_DEST: /tmp/.buildx-cache-new
   CACHE_FROM_SRC: /tmp/.buildx-cache
+  TAG_FALLBACK_STRING: tag-unavailable
 
 jobs:
   build-and-push:
@@ -24,15 +26,15 @@ jobs:
     strategy:
       matrix:
         images:
+          - imageTag: 19-slim
+            dockerfile: src/Dockerfile.dev
+            additionalFilesToWatch: ""
+            readmeFile: src/DOCKER_README.md
           - imageTag: 18-slim
             dockerfile: src/Dockerfile.dev
             additionalFilesToWatch: ""
             readmeFile: src/DOCKER_README.md
           - imageTag: 17-slim
-            dockerfile: src/Dockerfile.dev
-            additionalFilesToWatch: ""
-            readmeFile: src/DOCKER_README.md
-          - imageTag: 16-slim
             dockerfile: src/Dockerfile.dev
             additionalFilesToWatch: ""
             readmeFile: src/DOCKER_README.md
@@ -57,14 +59,14 @@ jobs:
         id: latest_tag
         uses: WyriHaximus/github-action-get-previous-tag@v1
         with:
-          fallback: tag-unavailable
+          fallback: ${{ env.TAG_FALLBACK_STRING }}
 
       - name: Declare run state
         id: run_state
         run: |
           if [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
             [ ${{ github.event_name }} == workflow_dispatch ] || \
-            [ ${{ steps.latest_tag.outputs.tag }} != tag-unavailable ];
+            [ ${{ steps.latest_tag.outputs.tag }} != ${{ env.TAG_FALLBACK_STRING }} ];
           then
             echo "::set-output name=run_docker_build::true"
             echo "::debug::Docker build will carry out as expected."

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG IMAGE_TAG=10
+ARG IMAGE_TAG=16
 FROM node:$IMAGE_TAG
 
 ARG USERNAME
@@ -14,7 +14,17 @@ RUN echo "root:$ROOT_PASS" | chpasswd
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   git \
-  vim
+  wget \
+  libc6 \
+  libgcc-s1
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 USER $USERNAME
 

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh node vim git"
+required_packages="gh node nvim git"
 
 for exec in $required_packages;
 do


### PR DESCRIPTION
- Add nvim as this version of vim can also provide vscode with a server
- Set `EDITOR` as `nvim` in dockerfile env.
- Update `build-and-push.yml` workflow to use env based default tag.
- Add wget. This is done to allow installation of nvim, but it's a
  useful tool and will be kept.
